### PR TITLE
fix(video.js): upgrade video.js to fix bugs in the old version of video.js

### DIFF
--- a/whiteboard/package.json
+++ b/whiteboard/package.json
@@ -32,6 +32,7 @@
         "react-dom": "^16.13.1",
         "react-router": "^4.3.1",
         "react-router-dom": "^4.3.1",
+        "video.js": "^7.10.2",
         "white-web-sdk": "2.11.2"
     },
     "devDependencies": {


### PR DESCRIPTION
旧版的video.js有个bug，需要进行升级来修复，详情可见: https://github.com/videojs/video.js/issues/6909